### PR TITLE
Fix artwork gallery filter to allow missing gallery IDs

### DIFF
--- a/index.html
+++ b/index.html
@@ -2274,11 +2274,9 @@
                     }
 
                     const recordGalleryId = record['Gallery ID'] || record['Gallery'] || record['GalleryId'];
-                    if (galleryFilterId) {
-                        if (!recordGalleryId || recordGalleryId !== galleryFilterId) {
-                            console.log(`Skipping ${record.Title} because it belongs to a different gallery`, recordGalleryId);
-                            continue;
-                        }
+                    if (galleryFilterId && recordGalleryId && recordGalleryId !== galleryFilterId) {
+                        console.log(`Skipping ${record.Title} - belongs to ${recordGalleryId}`);
+                        continue;
                     }
 
                     const locationName = extractLocationValue(


### PR DESCRIPTION
## Summary
- update Airtable artwork filtering to only skip when a record has a non-matching gallery ID
- simplify skip logging to avoid filtering out artworks without gallery IDs

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_691cfb66c4708332b13a72c4a4677762)