### PR TITLE
Fix error

### DIFF
--- a/index.html
+++ b/index.html
@@ -5069,11 +5069,59 @@
             loadArtworksFromEvents();
         }
         
+        function checkWebGLSupport() {
+            try {
+                const canvas = document.createElement('canvas');
+                const gl = canvas.getContext('webgl2') || canvas.getContext('webgl') || canvas.getContext('experimental-webgl');
+                if (!gl) {
+                    return { supported: false, reason: 'WebGL is not supported by your browser or is disabled.' };
+                }
+                // Check if context was lost immediately (can happen with GPU issues)
+                if (gl.isContextLost && gl.isContextLost()) {
+                    return { supported: false, reason: 'WebGL context was lost. Your GPU may be unavailable.' };
+                }
+                return { supported: true, gl };
+            } catch (e) {
+                return { supported: false, reason: 'Error checking WebGL support: ' + e.message };
+            }
+        }
+
+        function createRenderer() {
+            // Try different renderer configurations in order of preference
+            const configs = [
+                { antialias: true, powerPreference: 'default' },
+                { antialias: false, powerPreference: 'low-power' },
+                { antialias: false, powerPreference: 'low-power', precision: 'lowp' }
+            ];
+
+            for (const config of configs) {
+                try {
+                    const testRenderer = new THREE.WebGLRenderer(config);
+                    // Verify the context was created successfully
+                    if (testRenderer.getContext()) {
+                        console.log('WebGL renderer created with config:', config);
+                        return testRenderer;
+                    }
+                    testRenderer.dispose();
+                } catch (e) {
+                    console.warn('Failed to create renderer with config:', config, e.message);
+                }
+            }
+            return null;
+        }
+
         function init() {
             try {
                 if (typeof THREE === 'undefined') {
                     throw new Error('THREE.js library failed to load. Check your network connection.');
                 }
+
+                // Check WebGL support before attempting to create renderer
+                const webglCheck = checkWebGLSupport();
+                if (!webglCheck.supported) {
+                    throw new Error(webglCheck.reason + '\n\nTry:\n• Enabling hardware acceleration in browser settings\n• Updating your graphics drivers\n• Using a different browser');
+                }
+
                 scene = new THREE.Scene();
                 scene.background = new THREE.Color(0xf0f0f0);
                 scene.fog = new THREE.Fog(0xf0f0f0, 10, 25);
@@ -5081,7 +5129,12 @@
                 camera = new THREE.PerspectiveCamera(75, window.innerWidth / window.innerHeight, 0.1, 1000);
                 camera.position.set(0, DEFAULT_EYE_LEVEL_METERS, 7);
 
-                renderer = new THREE.WebGLRenderer({ antialias: true });
+                // Create renderer with fallback configurations
+                renderer = createRenderer();
+                if (!renderer) {
+                    throw new Error('Failed to create WebGL renderer.\n\nThis may be caused by:\n• Too many browser tabs using WebGL\n• GPU memory exhaustion\n• Browser WebGL limits\n\nTry closing other tabs or restarting your browser.');
+                }
+
                 renderer.setSize(window.innerWidth, window.innerHeight);
                 renderer.shadowMap.enabled = true;
                 renderer.shadowMap.type = THREE.PCFSoftShadowMap;
@@ -5140,9 +5193,11 @@
                 console.error('Museum initialization failed:', error);
                 const loading = document.getElementById('loading');
                 if (loading) {
+                    // Format error message with proper line breaks for display
+                    const formattedMessage = error.message.replace(/\n/g, '<br>');
                     loading.innerHTML = `<div style="color: #ff4444; text-align: center; padding: 20px;">
                         <div style="font-size: 18px; margin-bottom: 10px;">Failed to load museum</div>
-                        <div style="font-size: 14px; color: #999;">${error.message}</div>
+                        <div style="font-size: 14px; color: #999; white-space: pre-line; text-align: left; display: inline-block;">${formattedMessage}</div>
                         <div style="font-size: 12px; color: #666; margin-top: 10px;">Check browser console for details</div>
                     </div>`;
                 }


### PR DESCRIPTION
- Add checkWebGLSupport() to detect WebGL availability before init
- Add createRenderer() with multiple fallback configurations:
  - First try antialias with default power preference
  - Then try without antialias and low-power mode
  - Finally try low precision as last resort
- Provide user-friendly error messages with troubleshooting steps
- Improve error display formatting for multi-line messages