### PR TITLE
Fix art gallery selection not saving

### DIFF
--- a/index.html
+++ b/index.html
@@ -4289,14 +4289,20 @@
                 closeCatalogue();
 
                 // Refresh gallery if we're in the target room
-                if (typeof roomManager !== 'undefined' && roomManager.currentRoomId === roomId) {
-                    // Load the artwork into the scene
-                    const artworkData = {
-                        id: objectId,
-                        ...eventData.data,
-                        placed: true
-                    };
-                    roomManager.addArtwork(artworkData);
+                if (typeof roomManager !== 'undefined' && roomManager.currentRoom === roomId) {
+                    // Load the artwork into the scene with correct data structure
+                    roomManager.addArtwork({
+                        roomId: roomId,
+                        locationId: locationId,
+                        url: selectedCatalogueItem.image_url,
+                        heightMeters: heightMeters,
+                        eventId: objectId,
+                        metadata: {
+                            title: title,
+                            artist: artist,
+                            description: description
+                        }
+                    });
                 }
 
                 alert(`"${title}" has been placed in ${locationName}!`);


### PR DESCRIPTION
Two bugs were preventing artwork from appearing after placement:
1. Used `roomManager.currentRoomId` which doesn't exist - fixed to use `currentRoom`
2. Artwork data structure didn't match what `addArtwork()` expects - fixed to pass correct properties (url, eventId, metadata) instead of spreading eventData.data