### PR TITLE
Fix apply crop functionality

### DIFF
--- a/index.html
+++ b/index.html
@@ -7747,6 +7747,7 @@
             document.getElementById('crop-aspect-ratio').value = 'free';
 
             const img = new Image();
+            img.crossOrigin = 'anonymous';
             img.onload = () => {
                 cropState.image = img;
 


### PR DESCRIPTION
Added crossOrigin = 'anonymous' attribute to the Image element in showCropDialog(). Without this, when cropping artwork with remote URLs (not data URLs), the canvas becomes tainted and toDataURL() throws a SecurityError, causing Apply Crop to silently fail.