### PR TITLE
Fix unable to add new room

### DIFF
--- a/index.html
+++ b/index.html
@@ -5569,6 +5569,16 @@
             // Save custom rooms to localStorage
             saveCustomRooms();
 
+            // Create a corresponding gallery entry for this room
+            const newGallery = {
+                id: roomId,
+                name: name,
+                homeRoom: roomId,
+                colorTemperature: themeConfig.colorTemperature
+            };
+            galleries.push(newGallery);
+            saveGalleryState();
+
             closeAddRoomDialog();
 
             // Show success message


### PR DESCRIPTION
When creating a new room, the code was only adding it to ROOMS but not creating a corresponding gallery entry. Since the gallery map displays galleries (not rooms directly), the new room would never appear.

Now createNewRoom() also creates a gallery entry that uses the new room as its homeRoom and saves it to localStorage.