### PR TITLE
Fix artwork not appearing on gallery wall

### DIFF
--- a/index.html
+++ b/index.html
@@ -4583,9 +4583,8 @@
                 closeCatalogueDetail();
                 closeCatalogue();
 
-                // Refresh gallery if we're in the target room
-                if (typeof roomManager !== 'undefined' && roomManager.currentRoom === roomId) {
-                    // Load the artwork into the scene with correct data structure
+                // Add artwork to the scene (loads immediately if in target room, otherwise queued for later)
+                if (typeof roomManager !== 'undefined') {
                     roomManager.addArtwork({
                         roomId: roomId,
                         locationId: locationId,


### PR DESCRIPTION
When placing artwork from catalogue while viewing a different room, the artwork was saved to the database but never added to the pending queue for display. Now roomManager.addArtwork() is always called, which correctly handles both cases: loading immediately if in the target room, or queuing for display when the user visits that room.