### PR TITLE
Fix menu button covering content

### DIFF
--- a/index.html
+++ b/index.html
@@ -156,7 +156,7 @@
         }
         
         #ui-overlay:not(.hidden) + #toggle-ui {
-            left: 360px;
+            left: calc(20px + min(360px, calc(100vw - 48px)) + 40px + 10px);
         }
         
         h2 {
@@ -1304,8 +1304,7 @@
             }
 
             #ui-overlay:not(.hidden) + #toggle-ui {
-                left: 16px;
-                top: 16px;
+                display: none;
             }
 
             .input-row {


### PR DESCRIPTION
- Adjust toggle-ui positioning to account for overlay padding (360px content + 40px padding + 10px gap)
- Hide toggle button on mobile when overlay is visible since it covers the full screen