### PR TITLE
Add gallery teleport and wall art display

### DIFF
--- a/index.html
+++ b/index.html
@@ -9238,6 +9238,7 @@
 
                     const entryDoorConfig = (targetRoom.doors || []).find(d => d.targetRoom === previousRoom);
                     if (entryDoorConfig) {
+                        // Enter through connected door
                         const entryPos = new THREE.Vector3(
                             targetRoom.position.x + entryDoorConfig.position.x,
                             1.6,
@@ -9261,6 +9262,9 @@
                             roomCenter.z - entryPos.z
                         );
                         camera.rotation.y = Math.atan2(-directionToCenter.x, -directionToCenter.y);
+                    } else {
+                        // Teleport to room center (no door connection - clicked from map)
+                        this.centerCameraInRoom(targetRoom);
                     }
                 });
             }


### PR DESCRIPTION
Previously, clicking a gallery in the navigation map only worked if there was a direct door connection. Now when clicking any gallery, the camera properly teleports to the room center and the art on walls is visible.