### PR TITLE
Count only wall-displayed art in gallery rollup

### DIFF
--- a/index.html
+++ b/index.html
@@ -5753,6 +5753,17 @@
                 });
             }
 
+            // Get artworks placed on walls only (not floors)
+            getWallArtworks(galleryId = null) {
+                return this.getPlacedArtworks(galleryId).filter(artwork => {
+                    if (!artwork.location || !artwork.roomId) return false;
+                    const room = ROOMS[artwork.roomId];
+                    if (!room) return false;
+                    // Check if the location is a wall spot
+                    return room.walls.some(w => w.id === artwork.location);
+                });
+            }
+
             // Get artwork by ID
             getArtwork(objectId) {
                 return this.state.artworks[objectId] || null;
@@ -8285,8 +8296,8 @@
                     item.classList.add('current');
                 }
 
-                // Count artworks for this gallery
-                const artworkCount = eventStore.getPlacedArtworks(gallery.id).length;
+                // Count wall artworks for this gallery
+                const artworkCount = eventStore.getWallArtworks(gallery.id).length;
                 const artworkText = artworkCount === 1 ? '1 piece' : `${artworkCount} pieces`;
 
                 item.innerHTML = `


### PR DESCRIPTION
Gallery art count now uses getWallArtworks() which filters for artworks placed on walls, excluding floor placements.