### PR TITLE
Fix API content not loading

### DIFF
--- a/index.html
+++ b/index.html
@@ -9620,7 +9620,11 @@
                         spaceId: artwork.spaceId || null,
                         roomGuid: artwork.roomGuid || null,
                         locationId: parsedLocation.locationId,
-                        locationName: artwork.locationName || ''
+                        locationName: artwork.locationName || '',
+                        // E-commerce fields from API
+                        productUrl: artwork.productUrl || '',
+                        price: artwork.price,
+                        currency: artwork.currency || 'USD'
                     };
 
                     // Height in meters (default 36 inches = 0.9144m)


### PR DESCRIPTION
Add missing e-commerce fields (productUrl, price, currency) to metadata object when loading artworks from API events. These fields were available in the artwork state but not being passed to the viewer/edit panel.