### PR TITLE
Fix artwork loading from catalogue data

### DIFF
--- a/index.html
+++ b/index.html
@@ -7430,11 +7430,11 @@
                     colorTemperature: DEFAULT_COLOR_TEMPERATURE
                 },
                 walls: [
-                    // Back wall - spots 1, 2, 3
+                    // Back wall - back-1, back-2, back-3
                     {
-                        id: 'main-gallery:1',
-                        baseId: '1',
-                        displayName: '1',
+                        id: 'main-gallery:back-1',
+                        baseId: 'back-1',
+                        displayName: 'Back Left Wall',
                         position: wallSpotPosition(-4, -9.9),
                         wall: 'back',
                         rotation: 0,
@@ -7442,9 +7442,9 @@
                         wallLength: 16 * 0.3048
                     },
                     {
-                        id: 'main-gallery:2',
-                        baseId: '2',
-                        displayName: '2',
+                        id: 'main-gallery:back-2',
+                        baseId: 'back-2',
+                        displayName: 'Back Center Wall',
                         position: wallSpotPosition(0, -9.9),
                         wall: 'back',
                         rotation: 0,
@@ -7452,20 +7452,20 @@
                         wallLength: 16 * 0.3048
                     },
                     {
-                        id: 'main-gallery:3',
-                        baseId: '3',
-                        displayName: '3',
+                        id: 'main-gallery:back-3',
+                        baseId: 'back-3',
+                        displayName: 'Back Right Wall',
                         position: wallSpotPosition(4, -9.9),
                         wall: 'back',
                         rotation: 0,
                         maxWidth: 5,
                         wallLength: 16 * 0.3048
                     },
-                    // Right wall - spots 4, 5, 6
+                    // Right wall - right-1, right-2
                     {
-                        id: 'main-gallery:4',
-                        baseId: '4',
-                        displayName: '4',
+                        id: 'main-gallery:right-1',
+                        baseId: 'right-1',
+                        displayName: 'Right Front Wall',
                         position: wallSpotPosition(7.9, -4),
                         wall: 'right',
                         rotation: -Math.PI / 2,
@@ -7473,61 +7473,20 @@
                         wallLength: 20 * 0.3048
                     },
                     {
-                        id: 'main-gallery:5',
-                        baseId: '5',
-                        displayName: '5',
-                        position: wallSpotPosition(7.9, 0),
-                        wall: 'right',
-                        rotation: -Math.PI / 2,
-                        maxWidth: 6,
-                        wallLength: 20 * 0.3048
-                    },
-                    {
-                        id: 'main-gallery:6',
-                        baseId: '6',
-                        displayName: '6',
+                        id: 'main-gallery:right-2',
+                        baseId: 'right-2',
+                        displayName: 'Right Back Wall',
                         position: wallSpotPosition(7.9, 4),
                         wall: 'right',
                         rotation: -Math.PI / 2,
                         maxWidth: 6,
                         wallLength: 20 * 0.3048
                     },
-                    // Front wall - spots 7, 8, 9
+                    // Left wall - left-1, left-2
                     {
-                        id: 'main-gallery:7',
-                        baseId: '7',
-                        displayName: '7',
-                        position: wallSpotPosition(-4, 9.9),
-                        wall: 'front',
-                        rotation: Math.PI,
-                        maxWidth: 5,
-                        wallLength: 16 * 0.3048
-                    },
-                    {
-                        id: 'main-gallery:8',
-                        baseId: '8',
-                        displayName: '8',
-                        position: wallSpotPosition(0, 9.9),
-                        wall: 'front',
-                        rotation: Math.PI,
-                        maxWidth: 5,
-                        wallLength: 16 * 0.3048
-                    },
-                    {
-                        id: 'main-gallery:9',
-                        baseId: '9',
-                        displayName: '9',
-                        position: wallSpotPosition(2, 9.9),
-                        wall: 'front',
-                        rotation: Math.PI,
-                        maxWidth: 3,
-                        wallLength: 16 * 0.3048
-                    },
-                    // Left wall - spots 10, 11, 12
-                    {
-                        id: 'main-gallery:10',
-                        baseId: '10',
-                        displayName: '10',
+                        id: 'main-gallery:left-1',
+                        baseId: 'left-1',
+                        displayName: 'Left Front Wall',
                         position: wallSpotPosition(-7.9, -4),
                         wall: 'left',
                         rotation: Math.PI / 2,
@@ -7535,19 +7494,9 @@
                         wallLength: 20 * 0.3048
                     },
                     {
-                        id: 'main-gallery:11',
-                        baseId: '11',
-                        displayName: '11',
-                        position: wallSpotPosition(-7.9, 0),
-                        wall: 'left',
-                        rotation: Math.PI / 2,
-                        maxWidth: 6,
-                        wallLength: 20 * 0.3048
-                    },
-                    {
-                        id: 'main-gallery:12',
-                        baseId: '12',
-                        displayName: '12',
+                        id: 'main-gallery:left-2',
+                        baseId: 'left-2',
+                        displayName: 'Left Back Wall',
                         position: wallSpotPosition(-7.9, 4),
                         wall: 'left',
                         rotation: Math.PI / 2,
@@ -7555,7 +7504,38 @@
                         wallLength: 20 * 0.3048
                     }
                 ],
-                floors: [],
+                floors: [
+                    {
+                        id: 'main-gallery:floor-1',
+                        baseId: 'floor-1',
+                        displayName: 'Front Left',
+                        position: { x: -3, y: 0, z: 6 }
+                    },
+                    {
+                        id: 'main-gallery:floor-2',
+                        baseId: 'floor-2',
+                        displayName: 'Front Center',
+                        position: { x: 0, y: 0, z: 6 }
+                    },
+                    {
+                        id: 'main-gallery:floor-3',
+                        baseId: 'floor-3',
+                        displayName: 'Front Right',
+                        position: { x: 3, y: 0, z: 6 }
+                    },
+                    {
+                        id: 'main-gallery:floor-5',
+                        baseId: 'floor-5',
+                        displayName: 'Rear Right',
+                        position: { x: 3, y: 0, z: -6 }
+                    },
+                    {
+                        id: 'main-gallery:floor-center',
+                        baseId: 'floor-center',
+                        displayName: 'Center Stage',
+                        position: { x: 0, y: 0, z: 0 }
+                    }
+                ],
                 doors: [
                     {
                         id: 'door-to-contemporary',
@@ -7578,114 +7558,42 @@
                     colorTemperature: DEFAULT_COLOR_TEMPERATURE
                 },
                 walls: [
-                    // Back wall - spots 1, 2, 3, 4 (avoiding door at center x=0)
+                    // North wall (back) - north-1, north-2, north-3
                     {
-                        id: 'contemporary-wing:1',
-                        baseId: '1',
-                        displayName: '1',
-                        position: wallSpotPosition(-7, -7.9),
+                        id: 'contemporary-wing:north-1',
+                        baseId: 'north-1',
+                        displayName: 'Skyline Panel',
+                        position: wallSpotPosition(-5, -7.9),
                         wall: 'back',
                         rotation: 0,
-                        maxWidth: 4,
-                        wallLength: 20 * 0.3048
-                    },
-                    {
-                        id: 'contemporary-wing:2',
-                        baseId: '2',
-                        displayName: '2',
-                        position: wallSpotPosition(-3, -7.9),
-                        wall: 'back',
-                        rotation: 0,
-                        maxWidth: 3,
-                        wallLength: 20 * 0.3048
-                    },
-                    {
-                        id: 'contemporary-wing:3',
-                        baseId: '3',
-                        displayName: '3',
-                        position: wallSpotPosition(3, -7.9),
-                        wall: 'back',
-                        rotation: 0,
-                        maxWidth: 3,
-                        wallLength: 20 * 0.3048
-                    },
-                    {
-                        id: 'contemporary-wing:4',
-                        baseId: '4',
-                        displayName: '4',
-                        position: wallSpotPosition(7, -7.9),
-                        wall: 'back',
-                        rotation: 0,
-                        maxWidth: 4,
-                        wallLength: 20 * 0.3048
-                    },
-                    // Right wall - spots 5, 6, 7
-                    {
-                        id: 'contemporary-wing:5',
-                        baseId: '5',
-                        displayName: '5',
-                        position: wallSpotPosition(9.9, -3),
-                        wall: 'right',
-                        rotation: -Math.PI / 2,
                         maxWidth: 5,
-                        wallLength: 16 * 0.3048
+                        wallLength: 20 * 0.3048
                     },
                     {
-                        id: 'contemporary-wing:6',
-                        baseId: '6',
-                        displayName: '6',
-                        position: wallSpotPosition(9.9, 0),
-                        wall: 'right',
-                        rotation: -Math.PI / 2,
+                        id: 'contemporary-wing:north-2',
+                        baseId: 'north-2',
+                        displayName: 'Lightwell',
+                        position: wallSpotPosition(0, -7.9),
+                        wall: 'back',
+                        rotation: 0,
                         maxWidth: 5,
-                        wallLength: 16 * 0.3048
+                        wallLength: 20 * 0.3048
                     },
                     {
-                        id: 'contemporary-wing:7',
-                        baseId: '7',
-                        displayName: '7',
-                        position: wallSpotPosition(9.9, 3),
-                        wall: 'right',
-                        rotation: -Math.PI / 2,
+                        id: 'contemporary-wing:north-3',
+                        baseId: 'north-3',
+                        displayName: 'Glass Passage',
+                        position: wallSpotPosition(5, -7.9),
+                        wall: 'back',
+                        rotation: 0,
                         maxWidth: 5,
-                        wallLength: 16 * 0.3048
-                    },
-                    // Front wall - spots 8, 9, 10
-                    {
-                        id: 'contemporary-wing:8',
-                        baseId: '8',
-                        displayName: '8',
-                        position: wallSpotPosition(-5, 7.9),
-                        wall: 'front',
-                        rotation: Math.PI,
-                        maxWidth: 6,
                         wallLength: 20 * 0.3048
                     },
+                    // West wall (left) - west-1, west-2
                     {
-                        id: 'contemporary-wing:9',
-                        baseId: '9',
-                        displayName: '9',
-                        position: wallSpotPosition(0, 7.9),
-                        wall: 'front',
-                        rotation: Math.PI,
-                        maxWidth: 6,
-                        wallLength: 20 * 0.3048
-                    },
-                    {
-                        id: 'contemporary-wing:10',
-                        baseId: '10',
-                        displayName: '10',
-                        position: wallSpotPosition(5, 7.9),
-                        wall: 'front',
-                        rotation: Math.PI,
-                        maxWidth: 6,
-                        wallLength: 20 * 0.3048
-                    },
-                    // Left wall - spots 11, 12, 13
-                    {
-                        id: 'contemporary-wing:11',
-                        baseId: '11',
-                        displayName: '11',
+                        id: 'contemporary-wing:west-1',
+                        baseId: 'west-1',
+                        displayName: 'Chromatic Stack',
                         position: wallSpotPosition(-9.9, -3),
                         wall: 'left',
                         rotation: Math.PI / 2,
@@ -7693,27 +7601,69 @@
                         wallLength: 16 * 0.3048
                     },
                     {
-                        id: 'contemporary-wing:12',
-                        baseId: '12',
-                        displayName: '12',
-                        position: wallSpotPosition(-9.9, 0),
-                        wall: 'left',
-                        rotation: Math.PI / 2,
-                        maxWidth: 5,
-                        wallLength: 16 * 0.3048
-                    },
-                    {
-                        id: 'contemporary-wing:13',
-                        baseId: '13',
-                        displayName: '13',
+                        id: 'contemporary-wing:west-2',
+                        baseId: 'west-2',
+                        displayName: 'Cascade Wall',
                         position: wallSpotPosition(-9.9, 3),
                         wall: 'left',
                         rotation: Math.PI / 2,
                         maxWidth: 5,
                         wallLength: 16 * 0.3048
+                    },
+                    // East wall (right) - east-1, east-2
+                    {
+                        id: 'contemporary-wing:east-1',
+                        baseId: 'east-1',
+                        displayName: 'Spectrum Drift',
+                        position: wallSpotPosition(9.9, -3),
+                        wall: 'right',
+                        rotation: -Math.PI / 2,
+                        maxWidth: 5,
+                        wallLength: 16 * 0.3048
+                    },
+                    {
+                        id: 'contemporary-wing:east-2',
+                        baseId: 'east-2',
+                        displayName: 'Neon Strata',
+                        position: wallSpotPosition(9.9, 3),
+                        wall: 'right',
+                        rotation: -Math.PI / 2,
+                        maxWidth: 5,
+                        wallLength: 16 * 0.3048
                     }
                 ],
-                floors: [],
+                floors: [
+                    {
+                        id: 'contemporary-wing:floor-1',
+                        baseId: 'floor-1',
+                        displayName: 'Atrium Plinth',
+                        position: { x: -4, y: 0, z: -4 }
+                    },
+                    {
+                        id: 'contemporary-wing:floor-2',
+                        baseId: 'floor-2',
+                        displayName: 'Reflective Stage',
+                        position: { x: 0, y: 0, z: -4 }
+                    },
+                    {
+                        id: 'contemporary-wing:floor-3',
+                        baseId: 'floor-3',
+                        displayName: 'Aurora Base',
+                        position: { x: 4, y: 0, z: -4 }
+                    },
+                    {
+                        id: 'contemporary-wing:floor-4',
+                        baseId: 'floor-4',
+                        displayName: 'Sculpture Garden',
+                        position: { x: -4, y: 0, z: 4 }
+                    },
+                    {
+                        id: 'contemporary-wing:floor-5',
+                        baseId: 'floor-5',
+                        displayName: 'Light Pool',
+                        position: { x: 4, y: 0, z: 4 }
+                    }
+                ],
                 doors: [
                     {
                         id: 'door-to-main',
@@ -7739,18 +7689,20 @@
                     name: 'Main Gallery',
                     description: 'The primary exhibition space',
                     spaces: [
-                        { guid: 'space_001', legacySpotId: '1', name: 'Back Wall Left', wall: 'back', position: 1 },
-                        { guid: 'space_002', legacySpotId: '2', name: 'Back Wall Center', wall: 'back', position: 2 },
-                        { guid: 'space_003', legacySpotId: '3', name: 'Back Wall Right', wall: 'back', position: 3 },
-                        { guid: 'space_004', legacySpotId: '4', name: 'Right Wall Front', wall: 'right', position: 1 },
-                        { guid: 'space_005', legacySpotId: '5', name: 'Right Wall Center', wall: 'right', position: 2 },
-                        { guid: 'space_006', legacySpotId: '6', name: 'Right Wall Back', wall: 'right', position: 3 },
-                        { guid: 'space_007', legacySpotId: '7', name: 'Front Wall Left', wall: 'front', position: 1 },
-                        { guid: 'space_008', legacySpotId: '8', name: 'Front Wall Center', wall: 'front', position: 2 },
-                        { guid: 'space_009', legacySpotId: '9', name: 'Front Wall Right', wall: 'front', position: 3 },
-                        { guid: 'space_010', legacySpotId: '10', name: 'Left Wall Front', wall: 'left', position: 1 },
-                        { guid: 'space_011', legacySpotId: '11', name: 'Left Wall Center', wall: 'left', position: 2 },
-                        { guid: 'space_012', legacySpotId: '12', name: 'Left Wall Back', wall: 'left', position: 3 }
+                        // Wall spots
+                        { guid: 'space_001', legacySpotId: 'back-1', name: 'Back Left Wall', wall: 'back', position: 1 },
+                        { guid: 'space_002', legacySpotId: 'back-2', name: 'Back Center Wall', wall: 'back', position: 2 },
+                        { guid: 'space_003', legacySpotId: 'back-3', name: 'Back Right Wall', wall: 'back', position: 3 },
+                        { guid: 'space_004', legacySpotId: 'right-1', name: 'Right Front Wall', wall: 'right', position: 1 },
+                        { guid: 'space_005', legacySpotId: 'right-2', name: 'Right Back Wall', wall: 'right', position: 2 },
+                        { guid: 'space_006', legacySpotId: 'left-1', name: 'Left Front Wall', wall: 'left', position: 1 },
+                        { guid: 'space_007', legacySpotId: 'left-2', name: 'Left Back Wall', wall: 'left', position: 2 },
+                        // Floor spots
+                        { guid: 'space_008', legacySpotId: 'floor-1', name: 'Front Left', wall: 'floor', position: 1 },
+                        { guid: 'space_009', legacySpotId: 'floor-2', name: 'Front Center', wall: 'floor', position: 2 },
+                        { guid: 'space_010', legacySpotId: 'floor-3', name: 'Front Right', wall: 'floor', position: 3 },
+                        { guid: 'space_011', legacySpotId: 'floor-5', name: 'Rear Right', wall: 'floor', position: 5 },
+                        { guid: 'space_012', legacySpotId: 'floor-center', name: 'Center Stage', wall: 'floor', position: 4 }
                     ]
                 },
                 {
@@ -7759,19 +7711,20 @@
                     name: 'Contemporary Wing',
                     description: 'Modern and contemporary art collection',
                     spaces: [
-                        { guid: 'space_013', legacySpotId: '1', name: 'Back Wall Far Left', wall: 'back', position: 1 },
-                        { guid: 'space_014', legacySpotId: '2', name: 'Back Wall Left', wall: 'back', position: 2 },
-                        { guid: 'space_015', legacySpotId: '3', name: 'Back Wall Right', wall: 'back', position: 3 },
-                        { guid: 'space_016', legacySpotId: '4', name: 'Back Wall Far Right', wall: 'back', position: 4 },
-                        { guid: 'space_017', legacySpotId: '5', name: 'Right Wall Front', wall: 'right', position: 1 },
-                        { guid: 'space_018', legacySpotId: '6', name: 'Right Wall Center', wall: 'right', position: 2 },
-                        { guid: 'space_019', legacySpotId: '7', name: 'Right Wall Back', wall: 'right', position: 3 },
-                        { guid: 'space_020', legacySpotId: '8', name: 'Front Wall Left', wall: 'front', position: 1 },
-                        { guid: 'space_021', legacySpotId: '9', name: 'Front Wall Center', wall: 'front', position: 2 },
-                        { guid: 'space_022', legacySpotId: '10', name: 'Front Wall Right', wall: 'front', position: 3 },
-                        { guid: 'space_023', legacySpotId: '11', name: 'Left Wall Front', wall: 'left', position: 1 },
-                        { guid: 'space_024', legacySpotId: '12', name: 'Left Wall Center', wall: 'left', position: 2 },
-                        { guid: 'space_025', legacySpotId: '13', name: 'Left Wall Back', wall: 'left', position: 3 }
+                        // Wall spots
+                        { guid: 'space_013', legacySpotId: 'north-1', name: 'Skyline Panel', wall: 'back', position: 1 },
+                        { guid: 'space_014', legacySpotId: 'north-2', name: 'Lightwell', wall: 'back', position: 2 },
+                        { guid: 'space_015', legacySpotId: 'north-3', name: 'Glass Passage', wall: 'back', position: 3 },
+                        { guid: 'space_016', legacySpotId: 'west-1', name: 'Chromatic Stack', wall: 'left', position: 1 },
+                        { guid: 'space_017', legacySpotId: 'west-2', name: 'Cascade Wall', wall: 'left', position: 2 },
+                        { guid: 'space_018', legacySpotId: 'east-1', name: 'Spectrum Drift', wall: 'right', position: 1 },
+                        { guid: 'space_019', legacySpotId: 'east-2', name: 'Neon Strata', wall: 'right', position: 2 },
+                        // Floor spots
+                        { guid: 'space_020', legacySpotId: 'floor-1', name: 'Atrium Plinth', wall: 'floor', position: 1 },
+                        { guid: 'space_021', legacySpotId: 'floor-2', name: 'Reflective Stage', wall: 'floor', position: 2 },
+                        { guid: 'space_022', legacySpotId: 'floor-3', name: 'Aurora Base', wall: 'floor', position: 3 },
+                        { guid: 'space_023', legacySpotId: 'floor-4', name: 'Sculpture Garden', wall: 'floor', position: 4 },
+                        { guid: 'space_024', legacySpotId: 'floor-5', name: 'Light Pool', wall: 'floor', position: 5 }
                     ]
                 }
             ]
@@ -9148,6 +9101,7 @@
 
             createRoomSpots(roomGroup, roomConfig) {
                 const wallSpotsForRoom = [];
+                const floorSpotsForRoom = [];
 
                 roomConfig.walls.forEach(spot => {
                     const spotMesh = new THREE.Mesh(
@@ -9174,7 +9128,33 @@
                     roomGroup.add(spotMesh);
                 });
 
-                return { wallSpots: wallSpotsForRoom, floorSpots: [] };
+                // Create floor spots
+                if (roomConfig.floors && roomConfig.floors.length > 0) {
+                    roomConfig.floors.forEach(spot => {
+                        const spotMesh = new THREE.Mesh(
+                            new THREE.CylinderGeometry(0.8, 0.8, 0.05, 16),
+                            new THREE.MeshStandardMaterial({
+                                color: 0x667eea,
+                                emissive: 0x667eea,
+                                emissiveIntensity: 0.2,
+                                transparent: true,
+                                opacity: 0.3
+                            })
+                        );
+                        spotMesh.position.set(spot.position.x, 0.03, spot.position.z);
+                        spotMesh.name = 'floor-spot';
+                        spotMesh.visible = false;
+                        spotMesh.userData = {
+                            ...spot,
+                            roomId: roomConfig.id,
+                            occupied: false
+                        };
+                        floorSpotsForRoom.push(spotMesh);
+                        roomGroup.add(spotMesh);
+                    });
+                }
+
+                return { wallSpots: wallSpotsForRoom, floorSpots: floorSpotsForRoom };
             }
 
             createRoomLighting(roomGroup, roomConfig, spots) {
@@ -9902,13 +9882,22 @@
         const loadArtworksFromAirtable = loadArtworksFromEvents;
         
         async function loadImageFromURL(url, locationId, height, metadata, artworkId, artworkData = null) {
-            const wallSpot = wallSpots.find(s => s.userData.id === locationId);
-            if (!wallSpot) {
-                console.warn(`[loadImageFromURL] Wall spot not found for locationId: "${locationId}". Available spots:`, wallSpots.map(s => s.userData.id));
+            // Check for wall spot first
+            let spot = wallSpots.find(s => s.userData.id === locationId);
+            let isFloorPlacement = false;
+
+            // If not found in wall spots, check floor spots
+            if (!spot) {
+                spot = floorSpots.find(s => s.userData.id === locationId);
+                isFloorPlacement = true;
+            }
+
+            if (!spot) {
+                console.warn(`[loadImageFromURL] Spot not found for locationId: "${locationId}". Available wall spots:`, wallSpots.map(s => s.userData.id), 'Floor spots:', floorSpots.map(s => s.userData.id));
                 return;
             }
-            if (wallSpot.userData.occupied) {
-                console.warn(`[loadImageFromURL] Wall spot "${locationId}" is already occupied`);
+            if (spot.userData.occupied) {
+                console.warn(`[loadImageFromURL] Spot "${locationId}" is already occupied`);
                 return;
             }
 
@@ -9916,7 +9905,7 @@
             if (artworkData?.displayMode === 'grid' && artworkData?.images && artworkData.images.length > 1) {
                 beginArtworkLoad();
                 try {
-                    createGridLayout(wallSpot, artworkData.images, metadata, artworkId, artworkData);
+                    createGridLayout(spot, artworkData.images, metadata, artworkId, artworkData);
                 } catch (error) {
                     console.error('Failed to create grid layout:', error);
                 } finally {
@@ -9937,8 +9926,13 @@
                         try {
                             const scaledHeight = height * ARTWORK_SCALE_FACTOR;
                             const scaledWidth = scaledHeight * aspectRatio;
-                            createArtworkMesh(texture, metadata.title || 'Untitled', wallSpot,
-                                { width: scaledWidth, height: scaledHeight }, metadata, url, artworkId, artworkData);
+                            if (isFloorPlacement) {
+                                createFloorArtworkMesh(texture, metadata.title || 'Untitled', spot,
+                                    { width: scaledWidth, height: scaledHeight }, metadata, url, artworkId, artworkData);
+                            } else {
+                                createArtworkMesh(texture, metadata.title || 'Untitled', spot,
+                                    { width: scaledWidth, height: scaledHeight }, metadata, url, artworkId, artworkData);
+                            }
                         } catch (placementError) {
                             console.error('Failed to place artwork from URL:', placementError);
                         } finally {
@@ -9958,6 +9952,89 @@
                 };
                 img.src = url;
             });
+        }
+
+        // Create artwork on floor with easel
+        function createFloorArtworkMesh(texture, name, spot, size, metadata, imageUrl, artworkId, artworkData) {
+            const parentGroup = spot.parent || scene;
+            const { width, height } = size;
+
+            // Create easel group
+            const easelGroup = new THREE.Group();
+            easelGroup.name = 'floor-artwork';
+
+            // Create easel legs
+            const legMaterial = new THREE.MeshStandardMaterial({ color: 0x4a3728, roughness: 0.8, metalness: 0.1 });
+            const legGeometry = new THREE.CylinderGeometry(0.02, 0.02, 1.5, 8);
+
+            // Front legs
+            const leftLeg = new THREE.Mesh(legGeometry, legMaterial);
+            leftLeg.position.set(-0.15, 0.75, 0.1);
+            leftLeg.rotation.x = -Math.PI * 0.1;
+            easelGroup.add(leftLeg);
+
+            const rightLeg = new THREE.Mesh(legGeometry, legMaterial);
+            rightLeg.position.set(0.15, 0.75, 0.1);
+            rightLeg.rotation.x = -Math.PI * 0.1;
+            easelGroup.add(rightLeg);
+
+            // Back leg
+            const backLeg = new THREE.Mesh(new THREE.CylinderGeometry(0.02, 0.02, 1.4, 8), legMaterial);
+            backLeg.position.set(0, 0.7, -0.25);
+            backLeg.rotation.x = Math.PI * 0.15;
+            easelGroup.add(backLeg);
+
+            // Crossbar
+            const crossbar = new THREE.Mesh(new THREE.BoxGeometry(0.4, 0.03, 0.03), legMaterial);
+            crossbar.position.set(0, 1.0, 0.05);
+            easelGroup.add(crossbar);
+
+            // Create artwork canvas/frame
+            const canvasGeometry = new THREE.PlaneGeometry(width * 0.8, height * 0.8);
+            const canvasMaterial = new THREE.MeshStandardMaterial({
+                map: texture,
+                side: THREE.FrontSide,
+                roughness: 0.3
+            });
+            const canvas = new THREE.Mesh(canvasGeometry, canvasMaterial);
+            canvas.position.set(0, 1.2, 0.08);
+            canvas.rotation.x = -Math.PI * 0.08; // Slight tilt back
+            canvas.castShadow = true;
+            easelGroup.add(canvas);
+
+            // Set easel position at floor spot
+            easelGroup.position.copy(spot.position);
+            easelGroup.position.y = 0;
+
+            // Store metadata
+            easelGroup.userData = {
+                name: name,
+                spotId: spot.userData.id,
+                artworkId: artworkId,
+                metadata: metadata,
+                imageUrl: imageUrl,
+                isFloorArtwork: true,
+                gatewayTo: artworkData?.gatewayTo,
+                displayMode: artworkData?.displayMode,
+                images: artworkData?.images,
+                currentImageIndex: artworkData?.currentImageIndex || 0
+            };
+
+            artworks.push(easelGroup);
+            parentGroup.add(easelGroup);
+
+            // Create placard for floor artwork
+            const placard = createPlacard(metadata, spot.position, 0, true, width * 0.8, height * 0.8, parentGroup);
+            if (placard) {
+                easelGroup.userData.placardIndex = placards.indexOf(placard);
+            }
+
+            // Mark spot as occupied
+            spot.userData.occupied = true;
+            spot.material.color.setHex(0xff6b6b);
+            spot.material.emissive.setHex(0xff6b6b);
+
+            updateSpotCounters();
         }
         
         function generateArtworkId(title) {


### PR DESCRIPTION
…on IDs

- Updated main-gallery wall IDs to use semantic format (back-1, back-2, left-1, etc.)
- Updated contemporary-wing wall IDs to use semantic format (north-1, west-1, east-1, etc.)
- Added floor spot configurations for both rooms
- Updated ROOMS_CONFIG with matching legacySpotId values
- Added createRoomSpots function to create floor spots from config
- Added loadImageFromURL support for floor spot placements
- Added createFloorArtworkMesh function to render 2D artwork on easels

The location IDs in data.csv use semantic naming (main-gallery:back-2, contemporary-wing:north-1) which now properly match the ROOMS configuration.