### PR TITLE
Fix image dimensions in catalog

### DIFF
--- a/index.html
+++ b/index.html
@@ -2107,8 +2107,10 @@
         }
 
         .catalogue-grid.card-view .catalogue-item-image {
-            aspect-ratio: 9 / 16;
+            aspect-ratio: 9 / 16 !important;
             object-fit: cover;
+            width: 100%;
+            height: auto;
         }
 
         .catalogue-grid.card-view .catalogue-item-info {


### PR DESCRIPTION
- Add !important to aspect-ratio to ensure it takes precedence
- Add explicit width: 100% and height: auto for proper aspect ratio calculation
- Ensures catalog card images display in portrait orientation (9:16) instead of landscape