### PR TITLE
Fix art display bug on wall placement

### DIFF
--- a/index.html
+++ b/index.html
@@ -5791,6 +5791,12 @@
                                 roomGuid: normalizedData.roomGuid !== undefined ? normalizedData.roomGuid : this.state.artworks[object_id].roomGuid,
                                 updated_at: event.created_at || event.published
                             };
+                            // If location fields are cleared (set to null), mark as unplaced
+                            const artwork = this.state.artworks[object_id];
+                            const hasLocation = artwork.locationId || artwork.location || artwork.spaceId;
+                            if (!hasLocation) {
+                                artwork.placed = false;
+                            }
                         }
                         break;
                     case 'delete':


### PR DESCRIPTION
When an artwork's location is cleared via an update event, the placed flag was not being set to false, causing the artwork to still appear on the wall. Now checks if location fields are null after update and marks the artwork as unplaced.