### PR TITLE
Add menu items to art editing mode

### DIFF
--- a/index.html
+++ b/index.html
@@ -4620,6 +4620,20 @@
             <small style="opacity: 0.7; display: block; margin-top: 5px;">Slider mode: Click to cycle through images. Grid mode: Show all images at once.</small>
         </div>
 
+        <div class="section-divider">
+            <label>Room:</label>
+            <select id="edit-room-filter" onchange="filterEditLocations()">
+                <option value="">All Rooms</option>
+            </select>
+        </div>
+
+        <div class="section-divider">
+            <label>Location:</label>
+            <div id="edit-location-grid" class="location-grid"></div>
+        </div>
+
+        <div id="edit-size-warning" class="warning" style="display:none;"></div>
+
         <div style="display: flex; flex-direction: column; gap: 10px;">
             <div style="display: flex; gap: 10px;">
                 <button onclick="saveArtworkEdit()">Save Changes</button>
@@ -11044,6 +11058,76 @@
             return false;
         }
 
+        // Track selected location for edit dialog
+        let selectedEditLocation = null;
+
+        function filterEditLocations() {
+            const selectedRoomId = document.getElementById('edit-room-filter').value;
+            setupEditLocationGrid(selectedRoomId);
+        }
+
+        function setupEditLocationGrid(filterRoomId = null) {
+            const locationGrid = document.getElementById('edit-location-grid');
+            const warning = document.getElementById('edit-size-warning');
+
+            locationGrid.innerHTML = '';
+
+            warning.style.display = 'none';
+            warning.textContent = '';
+
+            const spots = wallSpots;
+            const currentSpotId = currentEditingArtwork ? currentEditingArtwork.userData.spotId : null;
+
+            spots.forEach(spotMesh => {
+                const pos = spotMesh.userData;
+
+                // Filter by room if specified
+                if (filterRoomId && pos.roomId !== filterRoomId) {
+                    return;
+                }
+
+                const locationOption = document.createElement('div');
+                locationOption.className = 'location-option';
+                locationOption.dataset.id = pos.id;
+
+                // Consider current artwork's spot as available (since we're moving it)
+                const isOccupied = spotMesh.userData.occupied && pos.id !== currentSpotId;
+                const isCurrentLocation = pos.id === currentSpotId;
+
+                if (isOccupied) {
+                    locationOption.classList.add('occupied');
+                }
+                if (isCurrentLocation) {
+                    locationOption.classList.add('selected');
+                    selectedEditLocation = pos.id;
+                }
+
+                const friendlyName = LOCATION_ID_TO_NAME_MAP[pos.id] || pos.displayName || pos.id;
+
+                locationOption.innerHTML = `
+                    <div class="location-name">${friendlyName}</div>
+                    <div class="location-status">${isCurrentLocation ? 'Current' : (isOccupied ? 'Occupied' : 'Available')}</div>
+                `;
+
+                if (!isOccupied) {
+                    locationOption.addEventListener('click', () => {
+                        locationGrid.querySelectorAll('.location-option').forEach(opt =>
+                            opt.classList.remove('selected'));
+                        locationOption.classList.add('selected');
+                        selectedEditLocation = pos.id;
+                    });
+                }
+
+                locationGrid.appendChild(locationOption);
+            });
+
+            // If no locations found for the selected room
+            if (locationGrid.children.length === 0) {
+                warning.textContent = 'No locations available in this room.';
+                warning.style.display = 'block';
+            }
+        }
+
         function showPlacementDialog(file, type, aspectRatio = null, imageUrl = null) {
             if (!isAdmin) return;
 
@@ -12521,6 +12605,25 @@
             const displayModeSelect = document.getElementById('edit-display-mode');
             displayModeSelect.value = artworkGroup.userData.displayMode || 'single';
 
+            // Populate room filter dropdown for location selection
+            const roomFilter = document.getElementById('edit-room-filter');
+            roomFilter.innerHTML = '<option value="">All Rooms</option>';
+            Object.values(ROOMS).forEach(room => {
+                const option = document.createElement('option');
+                option.value = room.id;
+                option.textContent = room.name;
+                roomFilter.appendChild(option);
+            });
+
+            // Get current artwork's room from its spot
+            const currentSpot = wallSpots.find(s => s.userData.id === artworkGroup.userData.spotId);
+            const currentRoomId = currentSpot ? currentSpot.userData.roomId : '';
+            roomFilter.value = currentRoomId;
+
+            // Set up location grid with current room filter
+            selectedEditLocation = artworkGroup.userData.spotId;
+            setupEditLocationGrid(currentRoomId);
+
             dialog.classList.add('active');
             document.exitPointerLock();
         }
@@ -12558,13 +12661,19 @@
             const gatewayTo = document.getElementById('edit-gateway-select').value;
             const displayMode = document.getElementById('edit-display-mode').value;
 
+            // Check if location has changed
+            const oldSpotId = currentEditingArtwork.userData.spotId;
+            const newSpotId = selectedEditLocation;
+            const locationChanged = newSpotId && newSpotId !== oldSpotId;
+
             // Create a hash of the edit data to detect duplicate submissions
             const editHash = JSON.stringify({
                 id: currentEditingArtwork.userData.artworkId,
                 ...newMetadata,
                 heightFeet,
                 gatewayTo,
-                displayMode
+                displayMode,
+                spotId: newSpotId
             });
 
             // Skip if this is the exact same edit as the last one
@@ -12579,6 +12688,63 @@
             currentEditingArtwork.userData.gatewayTo = gatewayTo;
             currentEditingArtwork.userData.displayMode = displayMode;
 
+            // Handle location change
+            let newSpot = null;
+            let newRoomId = null;
+            let newLocationName = null;
+            if (locationChanged) {
+                // Find old and new spots
+                const oldSpot = wallSpots.find(s => s.userData.id === oldSpotId);
+                newSpot = wallSpots.find(s => s.userData.id === newSpotId);
+
+                if (newSpot) {
+                    // Mark old spot as unoccupied
+                    if (oldSpot) {
+                        oldSpot.userData.occupied = false;
+                        oldSpot.userData.currentWidth = 0;
+                        oldSpot.material.color.setHex(0x667eea);
+                        oldSpot.material.emissive.setHex(0x667eea);
+                    }
+
+                    // Mark new spot as occupied
+                    newSpot.userData.occupied = true;
+                    newSpot.userData.currentWidth = currentEditingArtwork.userData.width;
+                    newSpot.material.color.setHex(0x4ade80);
+                    newSpot.material.emissive.setHex(0x4ade80);
+
+                    // Update artwork's spot reference
+                    currentEditingArtwork.userData.spotId = newSpotId;
+                    newRoomId = newSpot.userData.roomId;
+                    newLocationName = LOCATION_ID_TO_NAME_MAP[newSpotId] || newSpot.userData.displayName || newSpotId;
+
+                    // Move the artwork to the new position
+                    const artworkWidth = currentEditingArtwork.userData.width;
+                    const artworkHeight = currentEditingArtwork.children[1] ?
+                        currentEditingArtwork.children[1].geometry.parameters.height : artworkWidth;
+
+                    // Position artwork at new spot
+                    currentEditingArtwork.position.copy(newSpot.position);
+                    currentEditingArtwork.position.y = newSpot.position.y;
+
+                    // Apply rotation
+                    currentEditingArtwork.rotation.set(0, newSpot.userData.rotation, 0);
+
+                    // Offset slightly from wall
+                    const wallOffset = new THREE.Vector3(0, 0, 0.02);
+                    wallOffset.applyEuler(currentEditingArtwork.rotation);
+                    currentEditingArtwork.position.add(wallOffset);
+
+                    // Move to new room's parent if different
+                    if (newSpot.parent && currentEditingArtwork.parent !== newSpot.parent) {
+                        if (currentEditingArtwork.parent) {
+                            currentEditingArtwork.parent.remove(currentEditingArtwork);
+                        }
+                        newSpot.parent.add(currentEditingArtwork);
+                    }
+                }
+            }
+
+            // Update placard (at new or current location)
             if (currentEditingArtwork.userData.placardIndex !== undefined &&
                 placards[currentEditingArtwork.userData.placardIndex]) {
                 const oldPlacard = placards[currentEditingArtwork.userData.placardIndex];
@@ -12586,7 +12752,7 @@
                     oldPlacard.parent.remove(oldPlacard);
                 }
 
-                const spot = wallSpots.find(s => s.userData.id === currentEditingArtwork.userData.spotId);
+                const spot = newSpot || wallSpots.find(s => s.userData.id === currentEditingArtwork.userData.spotId);
                 if (spot) {
                     const artworkWidth = currentEditingArtwork.userData.width;
                     const artworkHeight = currentEditingArtwork.children[1].geometry.parameters.height;
@@ -12603,10 +12769,15 @@
             // Close dialog immediately for snappy UX
             cancelEdit();
 
+            // Update spot counters if location changed
+            if (locationChanged) {
+                updateSpotCounters();
+            }
+
             // DEFERRED XANO SYNC: Post update to XANO in background so everyone sees the same art
             if (artworkIdToUpdate) {
                 isSavingArtwork = true;
-                updateArtworkEvent({
+                const updateData = {
                     id: artworkIdToUpdate,
                     title: newMetadata.title,
                     artist: newMetadata.artist,
@@ -12617,9 +12788,22 @@
                     productUrl: newMetadata.productUrl,
                     price: newMetadata.price,
                     currency: newMetadata.currency
-                }).then(() => {
+                };
+
+                // Include location data if changed
+                if (locationChanged && newSpot) {
+                    updateData.location = newSpotId;
+                    updateData.locationName = newLocationName;
+                    updateData.roomId = newRoomId;
+                    updateData.currentlyPlaced = true;
+                }
+
+                updateArtworkEvent(updateData).then(() => {
                     lastArtworkEditHash = editHash;
                     console.log('Artwork edit synced to XANO');
+                    if (locationChanged) {
+                        showToast('Moved', `Artwork moved to ${newLocationName}`, 'success');
+                    }
                 }).catch(error => {
                     console.error('Failed to sync artwork edit to XANO:', error);
                     showToast('Sync Warning', 'Changes saved locally but failed to save online. Others may not see your changes until you retry.', 'warning', 8000);


### PR DESCRIPTION
Allow users to move artwork to different locations when editing, giving the edit dialog the same location selection capabilities as the placement dialog. Changes include:

- Add room filter dropdown to edit dialog
- Add location selector grid showing available spots
- Highlight current location and allow selecting new ones
- Handle artwork movement in 3D scene when location changes
- Sync location changes to backend