### PR TITLE
Fix room names display mismatch

### DIFF
--- a/index.html
+++ b/index.html
@@ -8275,7 +8275,10 @@
             // Always use main-gallery room
             if (roomManager && !options.skipRoomLoad) {
                 roomManager.loadRoom('main-gallery', { centerCamera: true });
-                // Update wall sign to show actual gallery name
+            }
+
+            // Always update wall sign to show actual gallery name
+            if (roomManager) {
                 updateRoomNameSign('main-gallery', gallery.name);
             }
 


### PR DESCRIPTION
The room name sign was showing the hardcoded "Room 1" instead of the actual gallery name because updateRoomNameSign was only called when skipRoomLoad was false. During initialization, setActiveGallery is called with skipRoomLoad: true, which skipped the sign update.

Move updateRoomNameSign outside of the skipRoomLoad condition so it always updates the sign when roomManager exists.