### PR TITLE
Simplify adding art to room spaces

### DIFF
--- a/index.html
+++ b/index.html
@@ -1939,67 +1939,6 @@
             resize: vertical;
         }
 
-        .catalogue-selected-spot .selected-spot-display {
-            display: flex;
-            align-items: center;
-            gap: 12px;
-            padding: 14px 16px;
-            background: linear-gradient(135deg, rgba(76, 175, 80, 0.25), rgba(56, 142, 60, 0.2));
-            border: 2px solid rgba(76, 175, 80, 0.5);
-            border-radius: 10px;
-        }
-
-        .catalogue-selected-spot .selected-spot-icon {
-            width: 36px;
-            height: 36px;
-            background: rgba(76, 175, 80, 0.3);
-            border-radius: 8px;
-            display: flex;
-            align-items: center;
-            justify-content: center;
-            flex-shrink: 0;
-        }
-
-        .catalogue-selected-spot .selected-spot-icon svg {
-            width: 20px;
-            height: 20px;
-            color: #4ade80;
-        }
-
-        .catalogue-selected-spot .selected-spot-info {
-            flex: 1;
-        }
-
-        .catalogue-selected-spot .selected-spot-label {
-            color: rgba(255, 255, 255, 0.7);
-            font-size: 11px;
-            text-transform: uppercase;
-            letter-spacing: 0.5px;
-            margin-bottom: 2px;
-        }
-
-        .catalogue-selected-spot .selected-spot-name {
-            color: #4ade80;
-            font-size: 15px;
-            font-weight: 600;
-        }
-
-        .catalogue-selected-spot .selected-spot-change {
-            padding: 6px 12px;
-            background: rgba(255, 255, 255, 0.1);
-            border: 1px solid rgba(255, 255, 255, 0.2);
-            color: rgba(255, 255, 255, 0.7);
-            border-radius: 4px;
-            font-size: 12px;
-            cursor: pointer;
-            transition: all 0.2s ease;
-        }
-
-        .catalogue-selected-spot .selected-spot-change:hover {
-            background: rgba(255, 255, 255, 0.15);
-            color: rgba(255, 255, 255, 0.9);
-        }
-
         .catalogue-detail-actions {
             display: flex;
             gap: 12px;
@@ -2057,7 +1996,7 @@
 
         .catalogue-table-header {
             display: grid;
-            grid-template-columns: 80px 2fr 1.5fr 1fr 1fr 1fr 100px;
+            grid-template-columns: 80px 2fr 1.5fr 1fr 1fr 100px;
             gap: 12px;
             padding: 12px 16px;
             background: rgba(255, 255, 255, 0.08);
@@ -2074,7 +2013,7 @@
 
         .catalogue-table-row {
             display: grid;
-            grid-template-columns: 80px 2fr 1.5fr 1fr 1fr 1fr 100px;
+            grid-template-columns: 80px 2fr 1.5fr 1fr 1fr 100px;
             gap: 12px;
             padding: 12px 16px;
             background: rgba(255, 255, 255, 0.03);
@@ -2118,10 +2057,6 @@
             color: #4ade80;
             font-weight: 500;
             font-size: 13px;
-        }
-
-        .catalogue-table-row .row-room-tag {
-            font-size: 12px;
         }
 
         .catalogue-table-row .row-status {
@@ -2919,17 +2854,6 @@
             color: white;
         }
 
-        /* Room Filter */
-        .catalogue-room-filter {
-            padding: 10px 14px;
-            border: 1px solid rgba(255, 255, 255, 0.2);
-            background: rgba(255, 255, 255, 0.05);
-            color: white;
-            border-radius: 8px;
-            font-size: 14px;
-            cursor: pointer;
-        }
-
         /* Table view responsive */
         @media (max-width: 900px) {
             .catalogue-table-header,
@@ -2938,9 +2862,7 @@
             }
 
             .catalogue-table-header > *:nth-child(3),
-            .catalogue-table-row > *:nth-child(3),
-            .catalogue-table-header > *:nth-child(6),
-            .catalogue-table-row > *:nth-child(6) {
+            .catalogue-table-row > *:nth-child(3) {
                 display: none;
             }
         }
@@ -4939,9 +4861,6 @@
                     <option value="unplaced">Not Placed</option>
                     <option value="placed">Placed</option>
                 </select>
-                <select class="catalogue-room-filter" id="catalogue-room-filter" onchange="filterCatalogue()">
-                    <option value="all">All Galleries</option>
-                </select>
                 <div class="catalogue-stats" id="catalogue-stats">0 items</div>
             </div>
             <div class="catalogue-grid table-view" id="catalogue-grid">
@@ -4978,28 +4897,7 @@
                         <label>Gallery</label>
                         <select id="catalogue-gallery"></select>
                     </div>
-                    <div id="catalogue-selected-spot" class="catalogue-selected-spot" style="display: none;">
-                        <div class="selected-spot-display">
-                            <div class="selected-spot-icon">
-                                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-                                    <path d="M21 10c0 7-9 13-9 13s-9-6-9-13a9 9 0 0 1 18 0z"/>
-                                    <circle cx="12" cy="10" r="3"/>
-                                </svg>
-                            </div>
-                            <div class="selected-spot-info">
-                                <div class="selected-spot-label">Will appear immediately at:</div>
-                                <span class="selected-spot-name" id="catalogue-selected-spot-name"></span>
-                            </div>
-                            <button class="selected-spot-change" onclick="toggleCatalogueLocationPicker()" title="Change location">Change</button>
-                        </div>
-                    </div>
-                    <div id="catalogue-room-picker" style="display: none;">
-                        <label>Room</label>
-                        <select id="catalogue-room-tag" onchange="onCatalogueRoomTagChange()">
-                            <option value="">No gallery</option>
-                        </select>
-                    </div>
-                    <div id="catalogue-location-picker">
+                    <div>
                         <label>Location</label>
                         <select id="catalogue-location"></select>
                     </div>
@@ -6172,34 +6070,11 @@
                     return;
                 }
                 catalogueDialog.classList.add('active');
-                populateRoomFilter();
                 renderCatalogue();
             } catch (error) {
                 console.error('Error opening catalogue:', error);
                 alert('Failed to open catalogue. Please try again.');
             }
-        }
-
-        // Populate room filter dropdown
-        function populateRoomFilter() {
-            const roomFilter = document.getElementById('catalogue-room-filter');
-            if (!roomFilter) return;
-
-            let options = '<option value="all">All Galleries</option>';
-            options += '<option value="untagged">Untagged</option>';
-
-            Object.values(ROOMS).forEach(room => {
-                options += `<option value="${room.id}">${room.name}</option>`;
-            });
-
-            roomFilter.innerHTML = options;
-        }
-
-        // Get room name by ID
-        function getRoomNameById(roomId) {
-            if (!roomId) return null;
-            const room = ROOMS[roomId];
-            return room ? room.name : roomId;
         }
 
         // Close catalogue dialog
@@ -6225,7 +6100,6 @@
                 const filterInput = document.getElementById('catalogue-filter');
                 const searchTerm = searchInput?.value?.toLowerCase() || '';
                 const filter = filterInput?.value || 'all';
-                const roomFilter = document.getElementById('catalogue-room-filter')?.value || 'all';
 
                 // Ensure artCatalogue is initialized
                 if (!Array.isArray(artCatalogue)) {
@@ -6245,10 +6119,6 @@
                     const isPlaced = isCatalogueItemPlaced(item.id);
                     if (filter === 'placed' && !isPlaced) return false;
                     if (filter === 'unplaced' && isPlaced) return false;
-
-                    // Room filter
-                    if (roomFilter === 'untagged' && item.roomTag) return false;
-                    if (roomFilter !== 'all' && roomFilter !== 'untagged' && item.roomTag !== roomFilter) return false;
 
                     return true;
                 });
@@ -6273,18 +6143,12 @@
 
         // Render table view with inline editing
         function renderTableView(grid, items) {
-            // Build room options for dropdown
-            const roomOptions = Object.values(ROOMS).map(room =>
-                `<option value="${room.id}">${room.name}</option>`
-            ).join('');
-
             const header = `
                 <div class="catalogue-table-header">
                     <div>Image</div>
                     <div>Title</div>
                     <div>Artist</div>
                     <div>Price</div>
-                    <div>Room Tag</div>
                     <div>Status</div>
                     <div>Actions</div>
                 </div>
@@ -6293,7 +6157,6 @@
             const rows = items.map(item => {
                 const isPlaced = isCatalogueItemPlaced(item.id);
                 const priceDisplay = item.price > 0 ? `$${item.price.toFixed(2)}` : 'N/A';
-                const roomName = getRoomNameById(item.roomTag);
                 const statusBadge = isPlaced
                     ? '<span class="status-badge placed">Placed</span>'
                     : '<span class="status-badge unplaced">Not placed</span>';
@@ -6314,14 +6177,6 @@
                                    onclick="event.stopPropagation()">
                         </div>
                         <div class="row-price">${priceDisplay}</div>
-                        <div class="row-room-tag">
-                            <select class="inline-edit-select" onchange="updateCatalogueItem('${item.id}', 'roomTag', this.value)" onclick="event.stopPropagation()">
-                                <option value="">No gallery</option>
-                                ${Object.values(ROOMS).map(room =>
-                                    `<option value="${room.id}" ${item.roomTag === room.id ? 'selected' : ''}>${room.name}</option>`
-                                ).join('')}
-                            </select>
-                        </div>
                         <div class="row-status">${statusBadge}</div>
                         <div class="row-actions">
                             <button class="catalogue-btn primary" onclick="event.stopPropagation(); openCatalogueDetail('${item.id}')">
@@ -6342,11 +6197,6 @@
 
             item[field] = value;
             saveCatalogue();
-
-            // Re-render if it's a room tag change (might affect filtering)
-            if (field === 'roomTag') {
-                renderCatalogue();
-            }
         }
 
         // Escape HTML to prevent XSS
@@ -6371,76 +6221,13 @@
             document.getElementById('catalogue-description').value = item.description || '';
             document.getElementById('catalogue-height').value = 36;
 
-            // Populate gallery dropdown using in-memory galleries (not stale localStorage)
+            // Populate gallery dropdown
             populateCatalogueGalleryDropdown();
 
-            // Populate room tag dropdown
-            const roomTagSelect = document.getElementById('catalogue-room-tag');
-            roomTagSelect.innerHTML = '<option value="">No gallery</option>' +
-                Object.values(ROOMS).map(room =>
-                    `<option value="${room.id}" ${item.roomTag === room.id ? 'selected' : ''}>${room.name}</option>`
-                ).join('');
-
-            // Check if we're coming from a spot click (user already selected where to place)
-            const pendingLocation = window.pendingCatalogueLocation;
-            const selectedSpotDisplay = document.getElementById('catalogue-selected-spot');
-            const roomPicker = document.getElementById('catalogue-room-picker');
-            const locationPicker = document.getElementById('catalogue-location-picker');
-
-            if (pendingLocation && pendingLocation.locationId) {
-                // User clicked on a spot first - show simplified UI with spot already selected
-                const locationName = pendingLocation.locationName || LOCATION_ID_TO_NAME_MAP[pendingLocation.locationId] || pendingLocation.locationId;
-                document.getElementById('catalogue-selected-spot-name').textContent = locationName;
-                selectedSpotDisplay.style.display = 'block';
-                roomPicker.style.display = 'none';
-                locationPicker.style.display = 'none';
-
-                // Still populate the location dropdown in case user wants to change
-                populateCatalogueLocations(pendingLocation.roomId, pendingLocation.locationId);
-
-                // Store pending location for placement (don't clear it)
-                window.catalogueSelectedFromSpot = pendingLocation;
-            } else {
-                // User opened catalogue directly - show full room/location pickers
-                selectedSpotDisplay.style.display = 'none';
-                roomPicker.style.display = 'block';
-                locationPicker.style.display = 'block';
-                window.catalogueSelectedFromSpot = null;
-
-                // Populate location dropdown with room tag priority
-                populateCatalogueLocations(item.roomTag);
-            }
-
-            // Clear the pending location
-            window.pendingCatalogueLocation = null;
+            // Populate location dropdown with all available spaces
+            populateCatalogueLocations();
 
             document.getElementById('catalogue-detail').classList.add('active');
-        }
-
-        // Toggle showing the location picker when user wants to change spot
-        function toggleCatalogueLocationPicker() {
-            const selectedSpotDisplay = document.getElementById('catalogue-selected-spot');
-            const locationPicker = document.getElementById('catalogue-location-picker');
-
-            // Hide the selected spot display and show the location dropdown
-            selectedSpotDisplay.style.display = 'none';
-            locationPicker.style.display = 'block';
-
-            // Clear the pre-selected spot so placement uses dropdown instead
-            window.catalogueSelectedFromSpot = null;
-        }
-
-        function onCatalogueRoomTagChange() {
-            const roomTag = document.getElementById('catalogue-room-tag').value;
-
-            // Update the catalogue item with the new room tag
-            if (selectedCatalogueItem) {
-                selectedCatalogueItem.roomTag = roomTag || undefined;
-                saveCatalogue();
-
-                // Refresh the location dropdown to show preferred spots
-                populateCatalogueLocations(roomTag);
-            }
         }
 
         // Populate gallery dropdown using in-memory galleries (not stale localStorage)
@@ -6465,10 +6252,9 @@
             }
         }
 
-        // Populate location dropdown based on selected gallery and room tag
-        function populateCatalogueLocations(preferredRoomId = null, preSelectedLocationId = null) {
+        // Populate location dropdown with all available wall spaces
+        function populateCatalogueLocations() {
             const locationSelect = document.getElementById('catalogue-location');
-            // Get placed artworks for the current gallery only - locations in other galleries are available
             const activeGallery = getActiveGallery();
             const galleryId = activeGallery?.id || null;
             const placedArtworks = eventStore.getPlacedArtworks(galleryId);
@@ -6476,53 +6262,28 @@
 
             let options = [];
 
-            // Add wall spots from all rooms
+            // Add wall spots from all rooms, grouped by room
             Object.values(ROOMS).forEach(room => {
                 room.walls.forEach(wall => {
                     const isOccupied = occupiedLocations.has(wall.id);
-                    const isPreferred = preferredRoomId && room.id === preferredRoomId;
                     options.push({
                         id: wall.id,
                         roomId: room.id,
                         name: `${room.name} - ${wall.displayName}`,
-                        type: 'wall',
-                        occupied: isOccupied,
-                        preferred: isPreferred
+                        occupied: isOccupied
                     });
                 });
             });
 
-            // Sort: pre-selected location first, then preferred room, then by room name
-            options.sort((a, b) => {
-                // Pre-selected location always first
-                if (preSelectedLocationId) {
-                    if (a.id === preSelectedLocationId) return -1;
-                    if (b.id === preSelectedLocationId) return 1;
-                }
-                if (a.preferred && !b.preferred) return -1;
-                if (!a.preferred && b.preferred) return 1;
-                return a.name.localeCompare(b.name);
-            });
+            // Sort by room name, then wall name
+            options.sort((a, b) => a.name.localeCompare(b.name));
 
-            // Determine which option to select:
-            // 1. Pre-selected location if available and not occupied
-            // 2. Otherwise first available in preferred room
-            let selectedOption = null;
-            if (preSelectedLocationId) {
-                const preSelected = options.find(opt => opt.id === preSelectedLocationId && !opt.occupied);
-                if (preSelected) {
-                    selectedOption = preSelected;
-                }
-            }
-            if (!selectedOption) {
-                selectedOption = options.find(opt => opt.preferred && !opt.occupied);
-            }
+            // Select first available spot by default
+            const firstAvailable = options.find(opt => !opt.occupied);
 
             locationSelect.innerHTML = options.map(opt => {
-                const isSelected = selectedOption && opt.id === selectedOption.id;
-                const isPreSelected = preSelectedLocationId && opt.id === preSelectedLocationId;
-                const label = isPreSelected ? `★ ${opt.name}` : (opt.preferred ? `★ ${opt.name}` : opt.name);
-                return `<option value="${opt.id}" ${opt.occupied ? 'disabled' : ''} ${isSelected ? 'selected' : ''}>${label}${opt.occupied ? ' (Occupied)' : ''}</option>`;
+                const isSelected = firstAvailable && opt.id === firstAvailable.id;
+                return `<option value="${opt.id}" ${opt.occupied ? 'disabled' : ''} ${isSelected ? 'selected' : ''}>${opt.name}${opt.occupied ? ' (Occupied)' : ''}</option>`;
             }).join('');
         }
 
@@ -6530,7 +6291,6 @@
         function closeCatalogueDetail() {
             document.getElementById('catalogue-detail').classList.remove('active');
             selectedCatalogueItem = null;
-            window.catalogueSelectedFromSpot = null;
         }
 
         // ==========================================
@@ -7183,10 +6943,7 @@
             const description = document.getElementById('catalogue-description').value.trim();
             const dropdownGalleryId = document.getElementById('catalogue-gallery').value;
             const heightInches = parseFloat(document.getElementById('catalogue-height').value) || 36;
-
-            // Use pre-selected spot from spot click, or fall back to dropdown
-            const preSelectedSpot = window.catalogueSelectedFromSpot;
-            const locationId = preSelectedSpot ? preSelectedSpot.locationId : document.getElementById('catalogue-location').value;
+            const locationId = document.getElementById('catalogue-location').value;
 
             if (!title || !artist) {
                 alert('Please enter a title and artist name.');
@@ -7215,9 +6972,6 @@
                     gallerySelect.value = galleryId;
                 }
             }
-
-            // Clear the pre-selected spot after use
-            window.catalogueSelectedFromSpot = null;
 
             // Find location details
             let locationName = '';
@@ -9123,14 +8877,7 @@
         }
 
         function assignFromCatalogue() {
-            if (!pendingAssignLocation) return;
-
-            // Save the location before closing the dialog (which clears pendingAssignLocation)
-            window.pendingCatalogueLocation = { ...pendingAssignLocation };
-
             closePlaceAssignDialog();
-
-            // Open catalogue with pre-selected location
             openCatalogue();
         }
 
@@ -12588,7 +12335,6 @@
             const priceValue = parseFloat(document.getElementById('price-input').value);
             const currency = document.getElementById('currency-input').value;
             const description = document.getElementById('description-input').value.trim();
-            const roomTag = document.getElementById('placement-room-filter').value;
 
             // Create catalogue item
             const catalogueItem = {
@@ -12599,8 +12345,7 @@
                 image_url: currentPendingArt.imageUrl,
                 product_url: productUrl || '',
                 price: !isNaN(priceValue) ? priceValue : 0,
-                currency: currency || 'USD',
-                roomTag: roomTag || undefined
+                currency: currency || 'USD'
             };
 
             // Add to catalogue


### PR DESCRIPTION
- Remove roomTag property from catalogue items (no longer used)
- Remove room filter dropdown from catalogue toolbar
- Remove room tag column from catalogue table view
- Simplify openCatalogueDetail to just populate form and locations
- Simplify populateCatalogueLocations to list all available wall spaces
- Remove unused CSS for selected-spot-display elements
- Remove unused functions: populateRoomFilter, getRoomNameById, onCatalogueRoomTagChange
- Clean up assignFromCatalogue to remove pendingCatalogueLocation logic

Art placement is now simpler: select catalogue item -> choose gallery ->
pick any available location from a single dropdown showing Room - Wall format.