### PR TITLE
Add embed functionality to spaces

### DIFF
--- a/index.html
+++ b/index.html
@@ -10560,6 +10560,37 @@
             return url.startsWith('data:') || url.includes(';base64,');
         }
 
+        // Helper function to detect if input is an iframe embed code
+        function isIframeEmbed(input) {
+            if (!input || typeof input !== 'string') return false;
+            const trimmed = input.trim();
+            return trimmed.startsWith('<iframe') && trimmed.includes('src=');
+        }
+
+        // Helper function to extract URL from iframe embed code
+        function extractUrlFromIframe(input) {
+            if (!input || typeof input !== 'string') return null;
+            // Match src attribute with either single or double quotes
+            const srcMatch = input.match(/src=["']([^"']+)["']/);
+            if (srcMatch && srcMatch[1]) {
+                return srcMatch[1];
+            }
+            return null;
+        }
+
+        // Helper function to process input - extracts URL from iframe if needed
+        function processMediaInput(input) {
+            if (!input || typeof input !== 'string') return input;
+            const trimmed = input.trim();
+            if (isIframeEmbed(trimmed)) {
+                const extractedUrl = extractUrlFromIframe(trimmed);
+                if (extractedUrl) {
+                    return extractedUrl;
+                }
+            }
+            return trimmed;
+        }
+
         // Helper function to detect video URLs
         function isVideoUrl(url) {
             if (!url || typeof url !== 'string') return false;
@@ -11815,9 +11846,9 @@
 
         function loadImageFromPlacementUrl() {
             const urlInput = document.getElementById('placement-image-url-input');
-            const url = urlInput.value.trim();
+            const rawInput = urlInput.value.trim();
 
-            if (!url) {
+            if (!rawInput) {
                 // Hide preview if URL is cleared
                 document.getElementById('image-preview').style.display = 'none';
                 if (currentPendingArt) {
@@ -11825,6 +11856,9 @@
                 }
                 return;
             }
+
+            // Process input - extract URL from iframe embed if needed
+            const url = processMediaInput(rawInput);
 
             // Block base64/data URLs
             if (isBase64Image(url)) {
@@ -11836,7 +11870,7 @@
             try {
                 new URL(url);
             } catch (e) {
-                alert('Please enter a valid URL');
+                alert('Please enter a valid URL or iframe embed code');
                 return;
             }
 
@@ -12681,18 +12715,21 @@
             }
 
             // Get and validate image/video URL from placement dialog
-            const imageUrl = document.getElementById('placement-image-url-input').value.trim();
-            if (!imageUrl) {
-                alert('Please enter an image or video URL');
+            const rawInput = document.getElementById('placement-image-url-input').value.trim();
+            if (!rawInput) {
+                alert('Please enter an image, video URL, or embed code');
                 document.getElementById('placement-image-url-input').focus();
                 return;
             }
+
+            // Process input - extract URL from iframe embed if needed
+            const imageUrl = processMediaInput(rawInput);
 
             // Validate URL format
             try {
                 new URL(imageUrl);
             } catch (e) {
-                alert('Please enter a valid URL');
+                alert('Please enter a valid URL or iframe embed code');
                 document.getElementById('placement-image-url-input').focus();
                 return;
             }
@@ -12776,18 +12813,21 @@
             }
 
             // Get and validate image/video URL from placement dialog
-            const imageUrl = document.getElementById('placement-image-url-input').value.trim();
-            if (!imageUrl) {
-                alert('Please enter an image or video URL');
+            const rawInput = document.getElementById('placement-image-url-input').value.trim();
+            if (!rawInput) {
+                alert('Please enter an image, video URL, or embed code');
                 document.getElementById('placement-image-url-input').focus();
                 return;
             }
+
+            // Process input - extract URL from iframe embed if needed
+            const imageUrl = processMediaInput(rawInput);
 
             // Validate URL format
             try {
                 new URL(imageUrl);
             } catch (e) {
-                alert('Please enter a valid URL');
+                alert('Please enter a valid URL or iframe embed code');
                 document.getElementById('placement-image-url-input').focus();
                 return;
             }


### PR DESCRIPTION
Allow users to paste iframe embed codes (like YouTube embeds) directly into the media URL input field. The system extracts the src URL from the iframe and processes it as a regular media URL.

Added helper functions:
- isIframeEmbed(): detects iframe HTML input
- extractUrlFromIframe(): extracts src URL from iframe
- processMediaInput(): unified input processing

Updated loadImageFromPlacementUrl, addToCatalogueOnly, and placeArtwork to support iframe embeds alongside direct URLs.