### PR TITLE
Fix auto-movement when entering room

### DIFF
--- a/index.html
+++ b/index.html
@@ -10367,6 +10367,16 @@
                     return;
                 }
 
+                // Reset all movement state to prevent auto-movement after room entry
+                moveForward = false;
+                moveBackward = false;
+                moveLeft = false;
+                moveRight = false;
+                if (velocity) velocity.set(0, 0, 0);
+                joystickData.active = false;
+                joystickData.x = 0;
+                joystickData.y = 0;
+
                 this.fadeTransition(async () => {
                     this.loadRoom(targetRoomId);
 


### PR DESCRIPTION
Reset movement state (moveForward, moveBackward, moveLeft, moveRight), velocity, and joystick data when transitioning to a new room. This prevents the bug where users would continue moving automatically after clicking on a gateway if they were holding movement keys.