### PR TITLE
Fix gallery piece count display bug

### DIFF
--- a/index.html
+++ b/index.html
@@ -6083,7 +6083,7 @@
             // Count unique filled spaces for a gallery
             // This counts how many distinct wall spaces have something placed in them
             getFilledSpaceCount(galleryId = null) {
-                const placedArtworks = this.getPlacedArtworks(galleryId);
+                const placedArtworks = this.getWallArtworks(galleryId);
                 const filledSpaces = new Set();
 
                 placedArtworks.forEach(artwork => {


### PR DESCRIPTION
The getFilledSpaceCount function was using getPlacedArtworks() which includes all placed artworks (including floor pieces), causing inflated counts. Changed to use getWallArtworks() to only count pieces actually on wall spots.