### PR TITLE
Fix catalogue item room and space numbering

### DIFF
--- a/index.html
+++ b/index.html
@@ -7016,7 +7016,7 @@
 
             listEl.innerHTML = placements.map(placement => {
                 const roomName = ROOM_ID_TO_NAME_MAP[placement.roomId] || placement.roomId || 'Unknown Gallery';
-                const locationName = placement.locationName || LOCATION_ID_TO_NAME_MAP[placement.locationId] || placement.locationId || 'Unknown Location';
+                const locationName = LOCATION_ID_TO_NAME_MAP[placement.locationId] || placement.locationName || placement.locationId || 'Unknown Location';
 
                 // Format date
                 let dateStr = '';
@@ -10903,7 +10903,7 @@
                         spaceId: artwork.spaceId || null,
                         roomGuid: artwork.roomGuid || null,
                         locationId: parsedLocation.locationId,
-                        locationName: artwork.locationName || '',
+                        locationName: LOCATION_ID_TO_NAME_MAP[parsedLocation.locationId] || artwork.locationName || '',
                         // E-commerce fields from API
                         productUrl: artwork.productUrl || '',
                         price: artwork.price,


### PR DESCRIPTION
Previously, location names like "Back Center Wall" or "Cascade Wall" were stored in the database and displayed as-is. Now the code prefers the current LOCATION_ID_TO_NAME_MAP mapping (which uses "Room X - Space Y" format) over the stored legacy names.

Changes:
- Line 7019: Display placements using current mapping first
- Line 10906: Load artwork metadata using current mapping first

This ensures all location names display consistently as "Room 1 - Space 3" instead of old descriptive names.