### PR TITLE
Fix image crop not persisting on refresh

### DIFF
--- a/index.html
+++ b/index.html
@@ -5919,7 +5919,9 @@
                     'gateway_to': 'gatewayTo',
                     'current_image_index': 'currentImageIndex',
                     'created_at': 'createdAt',
-                    'updated_at': 'updatedAt'
+                    'updated_at': 'updatedAt',
+                    'crop_data': 'cropData',
+                    'aspect_ratio': 'aspectRatio'
                 };
 
                 const normalized = { ...data };
@@ -10963,7 +10965,10 @@
                             currentImageIndex: artwork.currentImageIndex,
                             // Include spaceId for GUID-based location tracking
                             spaceId: artwork.spaceId,
-                            roomGuid: artwork.roomGuid
+                            roomGuid: artwork.roomGuid,
+                            // Include crop data for persisted crops
+                            cropData: artwork.cropData,
+                            aspectRatio: artwork.aspectRatio
                         }, loadGeneration)
                     );
                 }


### PR DESCRIPTION
The crop data was being saved to the database correctly but wasn't being loaded back when artworks were rendered:

1. Added crop_data and aspect_ratio to the field normalization map for snake_case to camelCase conversion (defensive measure)

2. Added cropData and aspectRatio to the entry object passed to roomManager.addArtwork() in loadArtworksFromEvents(), which was the main gap causing crops to not be applied on page load