### PR TITLE
Fix 16x9 video aspect ratio display

### DIFF
--- a/index.html
+++ b/index.html
@@ -11278,8 +11278,10 @@
                 video.play().catch(() => {}); // Ignore initial play errors, will retry in onloadedmetadata
 
                 video.onloadedmetadata = () => {
-                    // Use 16:9 aspect ratio for videos as specified
-                    const aspectRatio = artworkData?.aspectRatio || 16 / 9;
+                    // Use actual video dimensions to calculate aspect ratio
+                    const aspectRatio = (video.videoWidth && video.videoHeight)
+                        ? video.videoWidth / video.videoHeight
+                        : (artworkData?.aspectRatio || 16 / 9);
                     const scaledHeight = height * ARTWORK_SCALE_FACTOR;
                     const scaledWidth = scaledHeight * aspectRatio;
 


### PR DESCRIPTION
Instead of relying on potentially incorrect stored aspectRatio data, now reads videoWidth/videoHeight from the video element metadata to display videos with their correct native aspect ratio.