### PR TITLE
Fix black flashing bar in GA interface

### DIFF
--- a/index.html
+++ b/index.html
@@ -4371,6 +4371,12 @@
             max-height: 100%;
             object-fit: contain;
             cursor: pointer;
+            background: transparent;
+        }
+
+        /* Hide video when container is not active to prevent flash */
+        #viewer-video-container:not(.active) #viewer-video {
+            visibility: hidden;
         }
 
         /* Fullscreen video styles */
@@ -4438,10 +4444,15 @@
 
         #viewer-youtube {
             width: 100%;
-            height: 100%;
             max-width: 100%;
             max-height: 100%;
             aspect-ratio: 16 / 9;
+            background: transparent;
+        }
+
+        /* Hide iframe when container is not active to prevent flash */
+        #viewer-youtube-container:not(.active) #viewer-youtube {
+            visibility: hidden;
         }
 
         /* Hide image container when YouTube is active */
@@ -11364,7 +11375,7 @@
 
                 iframeContainer.style.width = `${iframeWidth}px`;
                 iframeContainer.style.height = `${iframeHeight}px`;
-                iframeContainer.style.backgroundColor = '#000';
+                iframeContainer.style.backgroundColor = 'transparent';
                 iframeContainer.style.position = 'relative';
                 iframeContainer.style.cursor = 'pointer';
 
@@ -11378,6 +11389,7 @@
                 thumbnail.style.position = 'absolute';
                 thumbnail.style.top = '0';
                 thumbnail.style.left = '0';
+                thumbnail.style.backgroundColor = '#000';
                 // Fallback to medium quality if maxres not available
                 thumbnail.onerror = function() {
                     this.src = `https://img.youtube.com/vi/${videoId}/hqdefault.jpg`;


### PR DESCRIPTION
- Changed YouTube iframe container background from black to transparent
- Moved black background to the thumbnail element instead
- Added visibility:hidden to video/YouTube elements when containers inactive
- This prevents CSS3D rendering artifacts that could cause black bars to flash